### PR TITLE
Add link to Pro Git book

### DIFF
--- a/ProGit.md
+++ b/ProGit.md
@@ -1,0 +1,1 @@
+[Pro Git](https://git-scm.com/book) - The entire Pro Git book, written by Scott Chacon and Ben Straub and published by Apress, is available here.


### PR DESCRIPTION
Add a link to the online reference book: Pro Git

closes #28 
